### PR TITLE
Support ALLOWED_HOSTS env var, fix Dockerfile missing source files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@
 
 # Clawdbot gateway auth token
 CLAWDBOT_API_TOKEN=
+
+# Comma-separated list of allowed hosts for the dev server
+# Example: ALLOWED_HOSTS=myhost.local,192.168.1.100,.mydomain.com
+ALLOWED_HOSTS=

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY package*.json ./
 RUN npm ci
 
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/vite.config.ts ./
+COPY --from=builder /app/tsconfig.json ./
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,4 +5,5 @@ services:
       - "3000:3000"
     environment:
       - CLAWDBOT_API_TOKEN=${CLAWDBOT_API_TOKEN}
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-}
     restart: unless-stopped

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,14 @@ import viteReact from '@vitejs/plugin-react'
 import viteTsConfigPaths from 'vite-tsconfig-paths'
 import tailwindcss from '@tailwindcss/vite'
 
+const allowedHosts = process.env.ALLOWED_HOSTS
+  ? process.env.ALLOWED_HOSTS.split(',').map(host => host.trim()).filter(Boolean)
+  : undefined
+
 export default defineConfig({
+  server: {
+    allowedHosts,
+  },
   plugins: [
     viteTsConfigPaths({
       projects: ['./tsconfig.json'],


### PR DESCRIPTION
## Summary
- Parse `ALLOWED_HOSTS` env var (comma-separated) into Vite `server.allowedHosts` for LAN/Tailscale access
- Fix Docker runtime stage: copy `src/`, `public/`, `vite.config.ts`, `tsconfig.json` (dev server needs these, only `dist/` was copied before)
- Pass `ALLOWED_HOSTS` through `docker-compose.yml`
- Document in `.env.example`

## Test plan
- [x] `npm run build` passes
- [x] `ALLOWED_HOSTS=myhost.local npm run dev` allows requests from `myhost.local`
- [x] Docker image builds and runs with `ALLOWED_HOSTS` set
- [x] Docker image runs without `ALLOWED_HOSTS` (no regression)

Ref #10