### PR TITLE
feat(monitor): infer spawnedBy for subagent sessions

### DIFF
--- a/src/integrations/clawdbot/parser.ts
+++ b/src/integrations/clawdbot/parser.ts
@@ -18,6 +18,7 @@ export function sessionInfoToMonitor(info: SessionInfo): MonitorSession {
     isGroup: parsed.isGroup,
     lastActivityAt: info.lastActivityAt,
     status: 'idle',
+    spawnedBy: info.spawnedBy,
   }
 }
 

--- a/src/integrations/clawdbot/protocol.ts
+++ b/src/integrations/clawdbot/protocol.ts
@@ -100,6 +100,8 @@ export interface SessionInfo {
   lastActivityAt: number
   messageCount: number
   lastMessage?: unknown
+  /** Session key of the parent session that spawned this subagent session. */
+  spawnedBy?: string
 }
 
 // App-level types
@@ -111,6 +113,8 @@ export interface MonitorSession {
   isGroup: boolean
   lastActivityAt: number
   status: 'idle' | 'active' | 'thinking'
+  /** Session key of the parent session that spawned this subagent session. */
+  spawnedBy?: string
 }
 
 export interface MonitorAction {


### PR DESCRIPTION
## Summary
- Client-side workaround for linking subagent sessions to parents without server support
- Tracks recent parent activity, infers spawn relationship within 5-second window
- Once set, spawnedBy is immutable (no flickering)

## Why
Moltbot PR for server-side `spawnedBy` was denied. This enables spawn visualization in PR #11 without gateway changes.

## Changes
- `protocol.ts`: Add `spawnedBy` field to `SessionInfo` and `MonitorSession`
- `parser.ts`: Transfer `spawnedBy` in `sessionInfoToMonitor`
- `collections.ts`: 
  - Track parent session activity timestamps
  - Infer parent when subagent first appears
  - Handle inference during hydration