### PR TITLE
feat(monitor): add configurable gateway URL in settings panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Add your environment variables here
 # Copy this file to .env.local and fill in your values
 
+# Clawdbot gateway WebSocket URL (optional, defaults to ws://127.0.0.1:18789)
+# This can be overridden at runtime via the Settings panel
+# CLAWDBOT_URL=ws://127.0.0.1:18789
+
 # Clawdbot gateway auth token
 CLAWDBOT_API_TOKEN=
 

--- a/src/integrations/clawdbot/index.ts
+++ b/src/integrations/clawdbot/index.ts
@@ -3,4 +3,29 @@ export * from './protocol'
 export * from './parser'
 export * from './collections'
 
+// Shared validation utilities
+export interface UrlValidationResult {
+  valid: boolean
+  error?: string
+}
+
+/**
+ * Validates a WebSocket URL format.
+ * Safe for both client and server use.
+ */
+export function validateGatewayUrl(url: string): UrlValidationResult {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+      return { valid: false, error: 'Must use ws:// or wss:// protocol' }
+    }
+    if (!parsed.hostname) {
+      return { valid: false, error: 'Hostname is required' }
+    }
+    return { valid: true }
+  } catch {
+    return { valid: false, error: 'Invalid URL format' }
+  }
+}
+
 // Server-only exports are in ./client.ts - import directly from there


### PR DESCRIPTION
Add runtime configuration for Clawdbot gateway WebSocket URL through the settings UI. Changes include server-side tRPC mutations for URL management, client-side localStorage persistence for user preferences, shared URL validation utilities, and UI controls for editing, saving, and resetting to defaults. Reconnects are handled automatically when switching URLs.

closes issue #27 