### PR TITLE
fix: truncate long paths in mobile workspace toolbar

### DIFF
--- a/src/components/workspace/MobileBottomToolbar.tsx
+++ b/src/components/workspace/MobileBottomToolbar.tsx
@@ -30,7 +30,7 @@ export function MobileBottomToolbar({
           {/* Files button */}
           <button
             onClick={onOpenDrawer}
-            className="p-3 min-w-[48px] min-h-[48px] rounded-lg active:bg-shell-800 text-gray-400 active:text-crab-400 transition-colors"
+            className="shrink-0 p-3 min-w-[48px] min-h-[48px] rounded-lg active:bg-shell-800 text-gray-400 active:text-crab-400 transition-colors"
           >
             <PanelLeft size={22} />
           </button>
@@ -38,7 +38,7 @@ export function MobileBottomToolbar({
           {/* Path input field */}
           <button
             onClick={onOpenPathSheet}
-            className="flex-1 flex items-center gap-2 px-3 py-2.5 bg-shell-800 border border-shell-700 rounded-lg active:border-crab-500 transition-colors min-h-[44px]"
+            className="flex-1 min-w-0 flex items-center gap-2 px-3 py-2.5 bg-shell-800 border border-shell-700 rounded-lg active:border-crab-500 transition-colors min-h-[44px] overflow-hidden"
           >
             <FolderOpen size={16} className={pathValid ? 'text-crab-400 shrink-0' : 'text-shell-500 shrink-0'} />
             <span className={`font-console text-sm truncate text-left ${currentPath ? 'text-gray-200' : 'text-shell-500'}`}>
@@ -50,7 +50,7 @@ export function MobileBottomToolbar({
           <button
             onClick={onRefresh}
             disabled={!pathValid || loading}
-            className="p-3 min-w-[48px] min-h-[48px] rounded-lg active:bg-shell-800 text-gray-400 active:text-crab-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            className="shrink-0 p-3 min-w-[48px] min-h-[48px] rounded-lg active:bg-shell-800 text-gray-400 active:text-crab-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
           >
             <RefreshCw size={22} className={loading ? 'animate-spin' : ''} />
           </button>


### PR DESCRIPTION
Fixes long file paths pushing the refresh button off-canvas on mobile.

- Add `shrink-0` to icon buttons to prevent shrinking
- Add `min-w-0 overflow-hidden` to path button to enable truncation

Reported by @Popidge in #33