### PR TITLE
fix: gateway password auth + login screen with auto-lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:22-alpine AS builder
 WORKDIR /app
 
+RUN apk add --no-cache python3 make g++
+
 COPY package*.json ./
 RUN npm ci
 
@@ -15,10 +17,10 @@ ENV PORT=3000
 ENV HOST=0.0.0.0
 ENV HOME=/root
 
-# Create workspace directory for volume mounting
 RUN mkdir -p /root/.openclaw/workspace
 
 COPY --from=builder /app/.output ./.output
+COPY --from=builder /app/node_modules ./node_modules
 
 EXPOSE 3000
 

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,2 @@
+export { LoginScreen } from './login-screen'
+export { ProtectedRoute } from './protected-route'

--- a/src/components/auth/login-screen.tsx
+++ b/src/components/auth/login-screen.tsx
@@ -1,0 +1,176 @@
+import { useState, useEffect, useRef, type FormEvent } from 'react'
+import { motion } from 'framer-motion'
+import { Lock, Key, Loader2 } from 'lucide-react'
+import { useAuth } from '~/hooks/use-auth'
+import { CrabIdleAnimation } from '~/components/ani'
+import { version } from '../../../package.json'
+
+export function LoginScreen() {
+  const [mode, setMode] = useState<'password' | 'token'>('password')
+  const [credential, setCredential] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { login, isAuthenticated } = useAuth()
+
+  // Auto-focus input on mount and mode change
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [mode])
+
+  // Clear input when switching modes
+  const handleModeChange = (newMode: 'password' | 'token') => {
+    setMode(newMode)
+    setCredential('')
+    setError(null)
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+
+    if (!credential.trim()) {
+      setError('Please enter a credential')
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+
+    const result = await login(credential, mode)
+
+    setLoading(false)
+
+    if (!result.success) {
+      setError(result.error || 'Authentication failed')
+      setCredential('')
+    }
+  }
+
+  if (isAuthenticated) return null
+
+  return (
+    <div className="fixed inset-0 z-[9999] bg-shell-950 texture-grid flex items-center justify-center">
+      {/* Background decorations */}
+      <div className="absolute inset-0 bg-linear-to-br from-crab-950/20 via-transparent to-shell-950" />
+      <div className="absolute top-0 left-0 w-96 h-96 bg-crab-600/5 rounded-full blur-3xl -translate-x-1/2 -translate-y-1/2" />
+      <div className="absolute bottom-0 right-0 w-80 h-80 bg-neon-coral/5 rounded-full blur-3xl translate-x-1/3 translate-y-1/3" />
+
+      {/* Login panel */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.9 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.3 }}
+        className="relative w-full max-w-md mx-4"
+      >
+        <div className="panel-retro p-8">
+          {/* Scanline texture overlay */}
+          <div className="absolute inset-0 texture-scanlines pointer-events-none opacity-20" />
+
+          {/* Crab icon */}
+          <div className="relative flex justify-center mb-6">
+            <div className="crab-icon-glow">
+              <CrabIdleAnimation className="w-20 h-20" />
+            </div>
+          </div>
+
+          {/* Title */}
+          <h1 className="font-arcade text-2xl text-center text-crab-400 glow-red mb-6 uppercase">
+            Access Control
+          </h1>
+
+          {/* Mode toggle */}
+          <div className="flex gap-2 mb-6">
+            <button
+              type="button"
+              onClick={() => handleModeChange('password')}
+              className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-all font-display text-xs uppercase tracking-wide ${
+                mode === 'password'
+                  ? 'bg-crab-600 text-white'
+                  : 'bg-shell-800 text-gray-400 hover:bg-shell-700'
+              }`}
+            >
+              <Lock size={14} />
+              Password
+            </button>
+            <button
+              type="button"
+              onClick={() => handleModeChange('token')}
+              className={`flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg transition-all font-display text-xs uppercase tracking-wide ${
+                mode === 'token'
+                  ? 'bg-crab-600 text-white'
+                  : 'bg-shell-800 text-gray-400 hover:bg-shell-700'
+              }`}
+            >
+              <Key size={14} />
+              Token
+            </button>
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block font-console text-xs text-shell-400 mb-2 uppercase">
+                {mode === 'password' ? 'Enter Password' : 'Enter API Token'}
+              </label>
+              <input
+                ref={inputRef}
+                type={mode === 'password' ? 'password' : 'text'}
+                value={credential}
+                onChange={(e) => setCredential(e.target.value)}
+                className="w-full px-4 py-3 bg-shell-900 border border-shell-700 rounded-lg font-console text-sm text-gray-200 focus:outline-none focus:border-crab-500 focus:ring-1 focus:ring-crab-500 transition-all"
+                placeholder={mode === 'password' ? '••••••••' : 'your-api-token'}
+                disabled={loading}
+              />
+            </div>
+
+            {/* Error message */}
+            {error && (
+              <motion.div
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="font-console text-xs text-crab-400 bg-crab-950/50 border border-crab-800 rounded px-3 py-2"
+              >
+                <span className="text-crab-600">&gt;</span> {error}
+              </motion.div>
+            )}
+
+            {/* Submit button */}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full btn-retro py-3 rounded-lg font-display text-sm uppercase tracking-wide disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {loading ? (
+                <>
+                  <Loader2 size={16} className="animate-spin" />
+                  Authenticating...
+                </>
+              ) : (
+                'Unlock Monitor'
+              )}
+            </button>
+          </form>
+
+          {/* Help text */}
+          <div className="mt-6 font-console text-[11px] text-shell-500 text-center space-y-1">
+            <p>
+              <span className="text-crab-600">&gt;</span> password from CLAWDBOT_PASSWORD env var
+            </p>
+            <p>
+              <span className="text-crab-600">&gt;</span> or token from CLAWDBOT_API_TOKEN
+            </p>
+          </div>
+        </div>
+
+        {/* Version badge */}
+        <div className="flex items-center justify-center gap-2 mt-4">
+          <span className="w-2 h-2 rounded-full bg-crab-500 animate-pulse" />
+          <span className="font-console text-[11px] text-shell-500">
+            crabwalk v{version} • auth required
+          </span>
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/src/components/auth/protected-route.tsx
+++ b/src/components/auth/protected-route.tsx
@@ -1,0 +1,32 @@
+import { useState, useEffect, type ReactNode } from 'react'
+import { Loader2 } from 'lucide-react'
+import { useAuth } from '~/hooks/use-auth'
+import { LoginScreen } from './login-screen'
+
+interface ProtectedRouteProps {
+  children: ReactNode
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isAuthenticated, isChecking } = useAuth()
+  const [ready, setReady] = useState(false)
+
+  // Wait for initial auth check to complete
+  useEffect(() => {
+    if (!isChecking) setReady(true)
+  }, [isChecking])
+
+  if (!ready) {
+    return (
+      <div className="h-screen flex items-center justify-center bg-shell-950">
+        <Loader2 className="w-6 h-6 animate-spin text-crab-400" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <LoginScreen />
+  }
+
+  return <>{children}</>
+}

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -1,0 +1,185 @@
+import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
+import { trpc } from '~/integrations/trpc/client'
+
+const SESSION_KEY = 'crabwalk_session_id'
+const TIMEOUT_KEY = 'crabwalk_timeout_duration'
+const DEFAULT_TIMEOUT = 15 * 60 * 1000 // 15 minutes
+
+interface AuthContextValue {
+  isAuthenticated: boolean
+  isLocked: boolean
+  isChecking: boolean
+  timeoutDuration: number
+  login: (credential: string, type: 'password' | 'token') => Promise<{ success: boolean; error?: string }>
+  logout: () => void
+  lock: () => void
+  setTimeoutDuration: (ms: number) => void
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [sessionId, setSessionId] = useState<string | null>(null)
+  const [isLocked, setIsLocked] = useState(false)
+  const [isChecking, setIsChecking] = useState(true)
+  const [timeoutDuration, setTimeoutDurationState] = useState(() => {
+    if (typeof window === 'undefined') return DEFAULT_TIMEOUT
+    const saved = localStorage.getItem(TIMEOUT_KEY)
+    if (saved) {
+      const ms = parseInt(saved, 10)
+      if (ms >= 300000 && ms <= 3600000) return ms
+    }
+    return DEFAULT_TIMEOUT
+  })
+  const lastActivityRef = useRef(Date.now())
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Initialize: check localStorage for existing session
+  useEffect(() => {
+    const stored = localStorage.getItem(SESSION_KEY)
+    if (stored) {
+      trpc.auth.check.query({ sessionId: stored })
+        .then(result => {
+          if (result.valid) {
+            setSessionId(stored)
+            lastActivityRef.current = Date.now()
+          } else {
+            localStorage.removeItem(SESSION_KEY)
+          }
+        })
+        .catch(() => {
+          localStorage.removeItem(SESSION_KEY)
+        })
+        .finally(() => setIsChecking(false))
+    } else {
+      setIsChecking(false)
+    }
+  }, [])
+
+  // Multi-tab sync: logout when another tab clears session
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === SESSION_KEY && e.newValue === null && sessionId) {
+        setSessionId(null)
+        setIsLocked(true)
+      }
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [sessionId])
+
+  // Activity tracker
+  const handleActivity = useCallback(() => {
+    lastActivityRef.current = Date.now()
+  }, [])
+
+  // Setup activity listeners when authenticated
+  useEffect(() => {
+    if (!sessionId) return
+
+    const events = ['mousemove', 'keydown', 'touchstart', 'click']
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+    const debouncedHandler = () => {
+      if (debounceTimer) return
+      debounceTimer = setTimeout(() => {
+        handleActivity()
+        debounceTimer = null
+      }, 1000)
+    }
+
+    events.forEach(event => {
+      window.addEventListener(event, debouncedHandler, { passive: true })
+    })
+
+    return () => {
+      events.forEach(event => {
+        window.removeEventListener(event, debouncedHandler)
+      })
+      if (debounceTimer) clearTimeout(debounceTimer)
+    }
+  }, [sessionId, handleActivity])
+
+  // Inactivity check every 10s
+  useEffect(() => {
+    if (!sessionId) return
+
+    timerRef.current = setInterval(() => {
+      const inactive = Date.now() - lastActivityRef.current
+      if (inactive > timeoutDuration) {
+        console.log('[auth] auto-lock triggered after', inactive, 'ms')
+        localStorage.removeItem(SESSION_KEY)
+        setSessionId(null)
+        setIsLocked(true)
+      }
+    }, 10000)
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [sessionId, timeoutDuration])
+
+  const login = useCallback(async (credential: string, type: 'password' | 'token') => {
+    try {
+      const result = await trpc.auth.verify.mutate({ credential, type })
+      if (result.success) {
+        localStorage.setItem(SESSION_KEY, result.sessionId)
+        setSessionId(result.sessionId)
+        setIsLocked(false)
+        lastActivityRef.current = Date.now()
+        return { success: true }
+      }
+      return { success: false, error: result.error }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : 'Login failed' }
+    }
+  }, [])
+
+  const logout = useCallback(() => {
+    const stored = localStorage.getItem(SESSION_KEY)
+    if (stored) {
+      trpc.auth.logout.mutate({ sessionId: stored }).catch(() => {})
+    }
+    localStorage.removeItem(SESSION_KEY)
+    setSessionId(null)
+    setIsLocked(false)
+  }, [])
+
+  const lock = useCallback(() => {
+    const stored = localStorage.getItem(SESSION_KEY)
+    if (stored) {
+      trpc.auth.logout.mutate({ sessionId: stored }).catch(() => {})
+    }
+    localStorage.removeItem(SESSION_KEY)
+    setSessionId(null)
+    setIsLocked(true)
+  }, [])
+
+  const setTimeoutDuration = useCallback((ms: number) => {
+    setTimeoutDurationState(ms)
+    localStorage.setItem(TIMEOUT_KEY, ms.toString())
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{
+      isAuthenticated: !!sessionId,
+      isLocked,
+      isChecking,
+      timeoutDuration,
+      login,
+      logout,
+      lock,
+      setTimeoutDuration,
+    }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext)
+  if (!context) {
+    throw new Error('useAuth must be used within AuthProvider')
+  }
+  return context
+}

--- a/src/integrations/openclaw/protocol.ts
+++ b/src/integrations/openclaw/protocol.ts
@@ -233,6 +233,7 @@ export function parseSessionKey(key: string): {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createConnectParams(token?: string): any {
+  const password = process.env.CLAWDBOT_PASSWORD
   return {
     minProtocol: 3,
     maxProtocol: 3,
@@ -249,6 +250,6 @@ export function createConnectParams(token?: string): any {
     permissions: {},
     locale: 'en-US',
     userAgent: 'crabwalk-monitor/0.1.0',
-    auth: token ? { token } : undefined,
+    auth: password ? { password } : token ? { token } : undefined,
   }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import { HeadContent, Scripts, createRootRoute, Link } from '@tanstack/react-rou
 import { motion } from 'framer-motion'
 import appCss from '../styles.css?url'
 import { QueryProvider } from '../integrations/query/provider'
+import { AuthProvider } from '../hooks/use-auth'
 import { CrabIdleAnimation } from '../components/ani'
 
 export const Route = createRootRoute({
@@ -69,7 +70,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body className="bg-shell-950 text-gray-100">
         <QueryProvider>
-          {children}
+          <AuthProvider>
+            {children}
+          </AuthProvider>
         </QueryProvider>
         <Scripts />
       </body>

--- a/src/routes/monitor/index.tsx
+++ b/src/routes/monitor/index.tsx
@@ -26,10 +26,15 @@ import {
   MobileMonitorToolbar,
 } from '~/components/monitor'
 import { CrabIdleAnimation } from '~/components/ani'
+import { ProtectedRoute } from '~/components/auth'
 import { useIsMobile } from '~/hooks/useIsMobile'
 
 export const Route = createFileRoute('/monitor/')({
-  component: MonitorPageWrapper,
+  component: () => (
+    <ProtectedRoute>
+      <MonitorPageWrapper />
+    </ProtectedRoute>
+  ),
 })
 
 // Wrapper to ensure client-only rendering (useLiveQuery needs client)

--- a/src/routes/workspace/index.tsx
+++ b/src/routes/workspace/index.tsx
@@ -28,6 +28,7 @@ import {
 } from '~/components/workspace'
 import { NavTabs } from '~/components/navigation'
 import { CrabIdleAnimation } from '~/components/ani'
+import { ProtectedRoute } from '~/components/auth'
 import { useIsMobile } from '~/hooks/useIsMobile'
 import type { DirectoryEntry } from '~/lib/workspace-fs'
 
@@ -45,7 +46,11 @@ function getParentDirPath(filePath: string): string {
 }
 
 export const Route = createFileRoute('/workspace/')({
-  component: WorkspacePageWrapper,
+  component: () => (
+    <ProtectedRoute>
+      <WorkspacePageWrapper />
+    </ProtectedRoute>
+  ),
 })
 
 // Wrapper to ensure client-only rendering

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,12 @@ export default defineConfig({
 		}),
 		tailwindcss(),
 		tanstackStart(),
-		nitro(),
+		nitro({
+			externals: {
+				inline: [],
+				external: ['ws', 'bufferutil', 'utf-8-validate'],
+			},
+		}),
 		viteReact(),
 	],
 });


### PR DESCRIPTION
## What's in here

Two things rolled into one branch:

### 1. Gateway password auth fix (previous commit)
- Support `CLAWDBOT_PASSWORD` env var for gateway password auth mode
- Fix `handleChallenge` early return when no token set
- Handle `ok: false` connect responses instead of silent timeout
- Add `WS_NO_BUFFER_UTIL=1` support for bundled ws environments
- Add `python3 make g++` to Dockerfile for arm64 native module compilation

### 2. Login screen + auth system (new)

Right now anyone with the URL can hit /monitor and /workspace. This adds a proper login screen so only people with the password or API token can get in.

**What you get:**
- **Login screen** — pops up when accessing /monitor or /workspace. Retro themed, password and token tabs, the whole vibe.
- **Auto-lock** — walk away for 15 min and it locks. Configurable 5-60 min in settings.
- **Settings panel** — new "Access Control" section with timeout slider and "Lock Now" button
- **Server sessions** — simple session IDs in a server Map, 24h TTL, auto-cleanup. No JWT, no new deps.
- **Security** — constant-time password comparison, credentials stay server-side, multi-tab logout sync

**Zero new dependencies.** Uses built-in `crypto.randomUUID()` and `crypto.timingSafeEqual()`.

Uses existing `CLAWDBOT_PASSWORD` / `CLAWDBOT_API_TOKEN` env vars — no new config needed.

## Test plan
- [ ] Connect with `CLAWDBOT_PASSWORD` set, verify gateway auth works
- [ ] Navigate to /monitor without login — see login screen
- [ ] Enter correct password — unlocks monitor
- [ ] Wrong password — error shown, input cleared
- [ ] Idle 15min — auto-locks
- [ ] Settings timeout slider + "Lock Now" button work
- [ ] Page refresh preserves session
- [ ] Lock in one tab locks all tabs